### PR TITLE
Small fix to addtrips - WHERE clause was returning multiple rows.

### DIFF
--- a/server/handlers/tripHandler.js
+++ b/server/handlers/tripHandler.js
@@ -31,7 +31,7 @@ let addTrip = async (req, res) => {
                      FROM users
                      WHERE email = ?), ?, ?
                     )`;
-  const params = ["Billybob", "React trip", "Bogus"]; //[req.body.email, req.body.name, req.body.dscript];
+  const params = [req.body.email, req.body.name, req.body.dscript];
   return databaseHandler.queryDatabaseBoolean(res, query, params, 'Add trip');
 };
 

--- a/server/handlers/tripHandler.js
+++ b/server/handlers/tripHandler.js
@@ -24,12 +24,14 @@ let getTrips = async (req, res) => {
  * @returns {Promise<void>} the promise indicating success
  */
 let addTrip = async (req, res) => {
+  console.log(req.body);
   const query = `INSERT INTO trips (user_id, name, dscript)
                   VALUES (
-                    (SELECT user_id FROM users
-                    WHERE email = ?), ?, ?
-                  )`;
-  const params = [req.body.email, req.body.name, req.body.dscript];
+                    (SELECT MAX(user_id) 
+                     FROM users
+                     WHERE email = ?), ?, ?
+                    )`;
+  const params = ["Billybob", "React trip", "Bogus"]; //[req.body.email, req.body.name, req.body.dscript];
   return databaseHandler.queryDatabaseBoolean(res, query, params, 'Add trip');
 };
 

--- a/server/server.js
+++ b/server/server.js
@@ -14,18 +14,14 @@ const tranRoutes = require('./controller/tranRoutes');
 const tripRoutes = require('./controller/tripRoutes');
 
 // App configuration
-app.use(
-  bodyParser.urlencoded({
-    extended: true
-  })
-);
-app.route('/*', (req, res) => {
-  res.redirect(__dirname + '/../dist/index.html');
-});
-app.use(express.static(path.join(__dirname, '/../dist')));
-app.use(express.json());
-app.use(bodyParser.json());
 app.use(Config.AccessControl);
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.route('/*', (req, res) => {
+  res.redirect(__dirname + '/../build/index.html');
+});
+app.use(express.static(path.join(__dirname, '/../build')));
+app.use(express.json());
 
 // App route configuration
 app.use('/', authRoutes); // Authentication routes


### PR DESCRIPTION
addTrip was failing due to the WHERE clause returning multiple rows; i.e. duplicate user_ids. This pull request contains a temporary fix for this issue. See issue #84 for a better solution.

Also, snuck into this pr are a few minor changes to the main server.js page.